### PR TITLE
Allow filtering user search args in select2 search query

### DIFF
--- a/src/Admin_Ajax.php
+++ b/src/Admin_Ajax.php
@@ -52,6 +52,7 @@ class Admin_Ajax {
 		if ( ! empty( $_GET['q'] ) ) {
 			$user_args['search'] = sanitize_text_field( '*' . $_GET['q'] . '*' );
 		}
+		$user_args = apply_filters( 'bylines_user_search_args', $user_args );
 		$users = get_users( $user_args );
 		$results = array();
 		foreach ( $users as $user ) {
@@ -151,6 +152,7 @@ class Admin_Ajax {
 				}
 			}
 		}
+		$user_args = apply_filters( 'bylines_user_search_args', $user_args );
 		$users = get_users( $user_args );
 		foreach ( $users as $user ) {
 			$bylines[] = array(


### PR DESCRIPTION
The ajax search query used to populate the meta box dropdown just gets all users on the current site. On sites with a very high number of users, this can lead to timeouts and database overloads. 

This PR adds filters around the `$user_args` passed to the WP_User_Query search to allow these queries to be filtered.