### PR TITLE
Make sure args value is int

### DIFF
--- a/src/Byline_Editor.php
+++ b/src/Byline_Editor.php
@@ -207,7 +207,7 @@ class Byline_Editor {
 			<td>
 				<?php
 				if ( 'image' === $args['type'] ) :
-					$byline_image = wp_get_attachment_image_url( $args['value'], 'thumbnail' );
+					$byline_image = wp_get_attachment_image_url( (int) $args['value'], 'thumbnail' );
 					?>
 					<div class="byline-image-field-wrapper">
 						<div class="byline-image-field-container">


### PR DESCRIPTION
@goldenapples Can I get a code review for this? We need to make sure that `wp_get_attachment_image_url` attachment id is a `int` otherwise it'll fatal with the new S3 changes.

Also once reviewed and you have time can you get another release ready?