### PR TITLE
Fix PHP 7.4 notice in Admin_Ajax class

### DIFF
--- a/src/Admin_Ajax.php
+++ b/src/Admin_Ajax.php
@@ -158,7 +158,7 @@ class Admin_Ajax {
 		if ( ! empty( $ignored ) ) {
 			$user_args['exclude'] = array();
 			foreach ( $ignored as $val ) {
-				if ( 'u' === $val[0] ) {
+				if ( ! is_numeric( $val ) && 'u' === $val[0] ) {
 					$user_args['exclude'][] = (int) substr( $val, 1 );
 				}
 			}


### PR DESCRIPTION
Adds a `! is_numeric` check before checking if `$val` begins with 'u' in class `Admin_Ajax`. This fixes a 'Trying to access array offset on value of type int' notice in PHP 7.4 if an int would be passed in the `$ignored` array to `get_possible_bylines_for_search`.

This fix makes the unit tests pass on PHP 7.4